### PR TITLE
chore: jsdom to 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "tsc --outDir dist && node test.js"
   },
   "dependencies": {
-    "jsdom": "^16.4.0",
+    "jsdom": "^19.0.0",
     "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue: https://github.com/jiyuujin/markdown-it-link-preview/issues/3

- added support for environments without SharedArrayBuffer
- webidl-conversions to 7
